### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,6 +1,8 @@
 ---
 
 name: Checks
+permissions:
+  contents: read
 
 on:  # yamllint disable-line rule:truthy
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Dutchman101/yamlfixer/security/code-scanning/10](https://github.com/Dutchman101/yamlfixer/security/code-scanning/10)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Since the workflow only needs to read repository contents (e.g., to run linters and tests), we will set `contents: read`. This ensures that the workflow does not have unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
