### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,5 +1,7 @@
 ---
 name: Publish Python packages to PyPI
+permissions:
+  contents: read
 
 on:  # yamllint disable-line rule:truthy
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Dutchman101/yamlfixer/security/code-scanning/4](https://github.com/Dutchman101/yamlfixer/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow involves checking out the repository and publishing to PyPI, it requires `contents: read` to read the repository contents and no other permissions. This block will be added at the root level of the workflow to apply to all jobs, ensuring minimal permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
