### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish_docker_hub.yml
+++ b/.github/workflows/publish_docker_hub.yml
@@ -11,6 +11,8 @@ jobs:
   build_and_publish_on_docker_hub:
     name: 🐳 Push Docker image to Docker Hub
     if: github.event.pull_request.merged
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo


### PR DESCRIPTION
Potential fix for [https://github.com/Dutchman101/yamlfixer/security/code-scanning/3](https://github.com/Dutchman101/yamlfixer/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow involves checking out the repository, preparing tags, logging into DockerHub, and building/pushing Docker images, the minimal required permissions are `contents: read` to access the repository's contents. No additional permissions are needed for the GITHUB_TOKEN in this workflow.

The `permissions` block will be added at the job level (`build_and_publish_on_docker_hub`) to limit its scope to this specific job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
