### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish_gh.yml
+++ b/.github/workflows/publish_gh.yml
@@ -12,6 +12,8 @@ jobs:
     # We publish only if tagged
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/Dutchman101/yamlfixer/security/code-scanning/1](https://github.com/Dutchman101/yamlfixer/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow creates a GitHub release, it requires `contents: read` and possibly `contents: write` permissions. However, we should avoid granting unnecessary permissions.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`new-gh-release`) to limit permissions to that job only. In this case, adding it to the job level is more precise and adheres to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
